### PR TITLE
adding explicit vpc as scope for Elastic IP creation

### DIFF
--- a/templates/dynatrace.template
+++ b/templates/dynatrace.template
@@ -506,12 +506,14 @@
         "EIP1" : {
  			"Type" : "AWS::EC2::EIP",
  			"Properties" : {
+                "Domain" : "vpc"
  			}
 		},
 
 		"EIP2" : {
 			"Type" : "AWS::EC2::EIP",
 			"Properties" : {
+                "Domain" : "vpc"
 			}
 		},
 
@@ -519,6 +521,7 @@
             "Type" : "AWS::EC2::EIP",
             "Condition" : "3AZCondition",
             "Properties" : {
+                "Domain" : "vpc"
             }
         },
 


### PR DESCRIPTION
I got reports that sometimes Elastic IPs are created in "standard" domain instead of VPC. Not sure if it is account or region specific, but now we explicitly set it to use vpc.